### PR TITLE
First parameter of Authorization header ignored

### DIFF
--- a/HTTP/OAuth/Provider/Request.php
+++ b/HTTP/OAuth/Provider/Request.php
@@ -151,11 +151,10 @@ class HTTP_OAuth_Provider_Request extends HTTP_OAuth_Message
             $this->debug('Using OAuth data from header');
             $parts = explode(',', $auth);
             foreach ($parts as $part) {
+                if (strstr(strtolower($part), 'oauth ') )
+                    $part = substr($part, 6);
                 list($key, $value) = explode('=', trim($part));
-                if (strstr(strtolower($key), 'oauth ')
-                    || strstr(strtolower($key), 'uth re')
-                    || substr(strtolower($key), 0, 6) != 'oauth_'
-                ) {
+                if (substr(strtolower($key), 0, 6) != 'oauth_') {
                     continue;
                 }
 


### PR DESCRIPTION
Ran into this issue while wrapping a REST API in OAuth using your library. Most clients seem to be fine with the current code, but a Java developer at my company was using the "Jersey" client, which does not send the realm header, and landed me in this arena.

Please forgive me if I am doing anything wrong in the process of submitting this patch to you - I am a newcomer to github.

In the current code, the very first parameter of the Authorization header will always be ommitted.

Example:
Authorization: OAuth oauth_signature="xxxxxx", realm="some_realm"

The oauth_signature parameter will be ommitted in this query. Normally,
a realm would be sent as the first parameter, which is handled in the
code, and ommitted properly. However, the OAuth 1.0a Core specification
does not impose any ordering of query parameters, including the realm.
This means that any parameter should be allowed to come first.

This patch examines the $parts variable before handing it to the
omission condition, enabling the explode() statements (and therefore the
rest of the fuction) to do their job.
